### PR TITLE
fix: windows CLI is installed in wrong location

### DIFF
--- a/templates/cli/install.ps1.twig
+++ b/templates/cli/install.ps1.twig
@@ -16,11 +16,14 @@
 $GITHUB_x64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-x64.exe"
 $GITHUB_arm64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-arm64.exe"
 
+${{ spec.title | upper }}_BINRARY_NAME = "{{ language.params.executableName }}.exe"
+
 # {{ spec.title | caseUcfirst }} download directory
-${{ spec.title | upper }}_DOWNLOAD_DIR = Join-Path -Path $env:TEMP -ChildPath "{{ language.params.executableName }}.exe"
+${{ spec.title | upper }}_DOWNLOAD_DIR = Join-Path -Path $env:TEMP -ChildPath ${{ spec.title | upper }}_BINRARY_NAME
 
 # {{ spec.title | caseUcfirst }} CLI location
 ${{ spec.title | upper }}_INSTALL_DIR = Join-Path -Path $env:LOCALAPPDATA -ChildPath "{{ spec.title | caseUcfirst }}"
+${{ spec.title | upper }}_INSTALL_PATH = Join-Path -Path "${{ spec.title | upper }}_INSTALL_DIR" -ChildPath "${{ spec.title | upper }}_BINRARY_NAME"
 
 $USER_PATH_ENV_VAR = [Environment]::GetEnvironmentVariable("PATH", "User")
 
@@ -53,8 +56,8 @@ function DownloadBinary {
       Invoke-WebRequest -Uri $GITHUB_x64_URL -OutFile ${{ spec.title | upper }}_DOWNLOAD_DIR
     }
    
-
-   Move-Item ${{ spec.title | upper }}_DOWNLOAD_DIR ${{ spec.title | upper }}_INSTALL_DIR
+   New-Item -ItemType Directory -Path ${{ spec.title | upper }}_INSTALL_DIR
+   Move-Item ${{ spec.title | upper }}_DOWNLOAD_DIR ${{ spec.title | upper }}_INSTALL_PATH
 }
 
 


### PR DESCRIPTION
Before this commit, when installing the CLI using this script, it would move the downloaded CLI executable
as a file to `%LOCALAPPDATA%/Appwrite` while it is inteded to move it to `%LOCALAPPDATA%/Appwrite/appwrite.exe`.

This commit fixes this problem by creating the directory explicitly and moving the file into it.

closes https://github.com/appwrite/appwrite/issues/3007